### PR TITLE
Fixing RBAC for cluster creation

### DIFF
--- a/deployments/helm/cma-vmware/templates/rbac.yaml
+++ b/deployments/helm/cma-vmware/templates/rbac.yaml
@@ -33,13 +33,13 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
-  verbs: ["get", "watch", "list", "patch", "delete"]
+  verbs: ["create", "get", "watch", "list", "patch", "delete"]
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "watch", "list", "delete"]
+  verbs: ["create", "get", "watch", "list", "delete"]
 - apiGroups: ["cluster.k8s.io"]
   resources: ["clusters", "machines"]
-  verbs: ["get", "watch", "list", "delete"]
+  verbs: ["create", "get", "watch", "list", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
On cluster creation I got the following errors on the cma-vmware:

- Error from server (Forbidden): error when creating "STDIN": namespaces is forbidden: User "system:serviceaccount:default:cma-vmware-serviceaccount" cannot create namespace at the cluster scope
- Error from server (Forbidden): error when creating "STDIN": clusters.cluster.k8s.io is forbidden: User "system:serviceaccount:default:cma-vmware-serviceaccount" cannot create namespace at the cluster scope
- Error from server (Forbidden): error when creating "STDIN": machines.cluster.k8s.io is forbidden: User "system:serviceaccount:default:cma-vmware-serviceaccount" cannot create namespace at the cluster scope

This updated RBAC manifest fixes those errors.