### PR TITLE
Prepare nodes with key

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,18 +2,6 @@
 
 
 [[projects]]
-  branch = "default"
-  name = "bitbucket.org/ww/goautoneg"
-  packages = ["."]
-  revision = "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
-
-[[projects]]
-  name = "github.com/NYTimes/gziphandler"
-  packages = ["."]
-  revision = "2600fb119af974220d3916a5916d6e31176aac1b"
-  version = "v1.0.1"
-
-[[projects]]
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
   revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
@@ -26,36 +14,6 @@
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/beorn7/perks"
-  packages = ["quantile"]
-  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
-
-[[projects]]
-  name = "github.com/coreos/etcd"
-  packages = ["auth/authpb","client","clientv3","etcdserver/api/v3rpc/rpctypes","etcdserver/etcdserverpb","mvcc/mvccpb","pkg/pathutil","pkg/srv","pkg/tlsutil","pkg/transport","pkg/types","version"]
-  revision = "fca8add78a9d926166eb739b8e4a124434025ba3"
-  version = "v3.3.9"
-
-[[projects]]
-  name = "github.com/coreos/go-semver"
-  packages = ["semver"]
-  revision = "8ab6407b697782a06568d4b7f1db25550ec2e4c6"
-  version = "v0.2.0"
-
-[[projects]]
-  name = "github.com/coreos/go-systemd"
-  packages = ["daemon"]
-  revision = "39ca1b05acc7ad1220e09f133283b8859a8b71ab"
-  version = "v17"
-
-[[projects]]
-  name = "github.com/davecgh/go-spew"
-  packages = ["spew"]
-  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
-  version = "v1.1.1"
-
-[[projects]]
   name = "github.com/elazarl/go-bindata-assetfs"
   packages = ["."]
   revision = "30f82fa23fd844bd5bb1e5f216db87fd77b5eb43"
@@ -63,21 +21,12 @@
 
 [[projects]]
   name = "github.com/emicklei/go-restful"
-  packages = [".","log"]
+  packages = [
+    ".",
+    "log"
+  ]
   revision = "3eb9738c1697594ea6e71a7156a9bb32ed216cf0"
   version = "v2.8.0"
-
-[[projects]]
-  name = "github.com/emicklei/go-restful-swagger12"
-  packages = ["."]
-  revision = "dcef7f55730566d41eae5db10e7d6981829720f6"
-  version = "1.0.1"
-
-[[projects]]
-  name = "github.com/evanphx/json-patch"
-  packages = ["."]
-  revision = "72bf35d0ff611848c1dc9df0f976c81192392fa5"
-  version = "v4.1.0"
 
 [[projects]]
   name = "github.com/fsnotify/fsnotify"
@@ -117,7 +66,10 @@
 
 [[projects]]
   name = "github.com/gogo/protobuf"
-  packages = ["gogoproto","proto","protoc-gen-gogo/descriptor","sortkeys"]
+  packages = [
+    "proto",
+    "sortkeys"
+  ]
   revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
   version = "v1.1.1"
 
@@ -129,7 +81,16 @@
 
 [[projects]]
   name = "github.com/golang/protobuf"
-  packages = ["jsonpb","proto","protoc-gen-go/descriptor","ptypes","ptypes/any","ptypes/duration","ptypes/struct","ptypes/timestamp"]
+  packages = [
+    "jsonpb",
+    "proto",
+    "protoc-gen-go/descriptor",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/struct",
+    "ptypes/timestamp"
+  ]
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
 
@@ -146,38 +107,49 @@
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
-  name = "github.com/google/uuid"
-  packages = ["."]
-  revision = "d460ce9f8df2e77fb1ba55ca87fafed96c607494"
-  version = "v1.0.0"
-
-[[projects]]
   name = "github.com/googleapis/gnostic"
-  packages = ["OpenAPIv2","compiler","extensions"]
+  packages = [
+    "OpenAPIv2",
+    "compiler",
+    "extensions"
+  ]
   revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
   version = "v0.2.0"
 
 [[projects]]
   branch = "master"
   name = "github.com/gregjones/httpcache"
-  packages = [".","diskcache"]
+  packages = [
+    ".",
+    "diskcache"
+  ]
   revision = "9cad4c3443a7200dd6400aef47183728de563a38"
 
 [[projects]]
   name = "github.com/grpc-ecosystem/grpc-gateway"
-  packages = ["protoc-gen-swagger/options","runtime","runtime/internal","utilities"]
+  packages = [
+    "protoc-gen-swagger/options",
+    "runtime",
+    "runtime/internal",
+    "utilities"
+  ]
   revision = "8558711daa6c2853489043207b563dceacbc19cf"
   version = "v1.5.0"
 
 [[projects]]
-  name = "github.com/hashicorp/golang-lru"
-  packages = [".","simplelru"]
-  revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
-  version = "v0.5.0"
-
-[[projects]]
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/printer","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/printer",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
   version = "v1.0.0"
 
@@ -218,12 +190,6 @@
   version = "1.0.1"
 
 [[projects]]
-  name = "github.com/kubernetes-incubator/apiserver-builder"
-  packages = ["pkg/builders"]
-  revision = "14201e804a58a140011a0044b15331f477535f91"
-  version = "v1.9-alpha.4"
-
-[[projects]]
   name = "github.com/magiconair/properties"
   packages = ["."]
   revision = "c2353362d570a7bfa228149c62842019201cfb71"
@@ -232,14 +198,12 @@
 [[projects]]
   branch = "master"
   name = "github.com/mailru/easyjson"
-  packages = ["buffer","jlexer","jwriter"]
+  packages = [
+    "buffer",
+    "jlexer",
+    "jwriter"
+  ]
   revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
-
-[[projects]]
-  name = "github.com/matttproud/golang_protobuf_extensions"
-  packages = ["pbutil"]
-  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
-  version = "v1.0.1"
 
 [[projects]]
   name = "github.com/mitchellh/mapstructure"
@@ -258,18 +222,6 @@
   packages = ["."]
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/mxk/go-flowrate"
-  packages = ["flowrate"]
-  revision = "cca7078d478f8520f85629ad7c68962d31ed7682"
-
-[[projects]]
-  name = "github.com/pborman/uuid"
-  packages = ["."]
-  revision = "adf5a7427709b9deb95d29d3fa8a2bf9cfd388f1"
-  version = "v1.2"
 
 [[projects]]
   name = "github.com/pelletier/go-toml"
@@ -296,36 +248,6 @@
   revision = "3dcc96556217539f50599357fb481ac0dc7439b9"
 
 [[projects]]
-  name = "github.com/prometheus/client_golang"
-  packages = ["prometheus"]
-  revision = "c5b7fccd204277076155f10851dad72b76a49317"
-  version = "v0.8.0"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/prometheus/client_model"
-  packages = ["go"]
-  revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/prometheus/common"
-  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
-  revision = "c7de2306084e37d54b8be01f3541a8464345e9a5"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/prometheus/procfs"
-  packages = [".","internal/util","nfs","xfs"]
-  revision = "05ee40e3a273f7245e8777337fc7b46e533a9a92"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/samsung-cnct/cluster-api-provider-ssh"
-  packages = ["cloud/ssh/providerconfig","cloud/ssh/providerconfig/v1alpha1"]
-  revision = "508da86e746bc0c1b5b167c222a547bc325cddbc"
-
-[[projects]]
   name = "github.com/soheilhy/cmux"
   packages = ["."]
   revision = "e09e9389d85d8492d313d73d1469c029e710623f"
@@ -333,7 +255,10 @@
 
 [[projects]]
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem"
+  ]
   revision = "d40851caa0d747393da1ffb28f7f9d8b4eeffebd"
   version = "v1.1.2"
 
@@ -368,56 +293,130 @@
   version = "v1.2.0"
 
 [[projects]]
-  name = "github.com/ugorji/go"
-  packages = ["codec"]
-  revision = "b4c50a2b199d93b13dc15e78929cfb23bfdf21ab"
-  version = "v1.1.1"
-
-[[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["ssh/terminal"]
+  packages = [
+    "curve25519",
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "internal/chacha20",
+    "internal/subtle",
+    "poly1305",
+    "ssh",
+    "ssh/terminal"
+  ]
   revision = "0e37d006457bf46f9e6692014ba72ef82c33022c"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp","html","html/atom","http/httpguts","http2","http2/hpack","idna","internal/timeseries","trace","websocket"]
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "http/httpguts",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/timeseries",
+    "trace"
+  ]
   revision = "26e67e76b6c3f6ce91f7c52def5af501b4e0f3a2"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/oauth2"
-  packages = [".","internal"]
+  packages = [
+    ".",
+    "internal"
+  ]
   revision = "d2e6202438beef2727060aa7cabdd924d92ebfd9"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "d0be0721c37eeb5299f245a996a483160fc36940"
 
 [[projects]]
   name = "golang.org/x/text"
-  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+    "width"
+  ]
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   name = "google.golang.org/appengine"
-  packages = ["internal","internal/base","internal/datastore","internal/log","internal/remote_api","internal/urlfetch","urlfetch"]
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch"
+  ]
   revision = "b1f26356af11148e710935ed1ac8a7f5702c7612"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
   name = "google.golang.org/genproto"
-  packages = ["googleapis/api/annotations","googleapis/rpc/status"]
+  packages = [
+    "googleapis/api/annotations",
+    "googleapis/rpc/status"
+  ]
   revision = "5a2fd4cab2d6d4a18e70c34937662526cd0c4bd1"
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [".","balancer","balancer/base","balancer/roundrobin","codes","connectivity","credentials","encoding","encoding/proto","grpclog","health/grpc_health_v1","internal","internal/backoff","internal/channelz","internal/envconfig","internal/grpcrand","internal/transport","keepalive","metadata","naming","peer","reflection","reflection/grpc_reflection_v1alpha","resolver","resolver/dns","resolver/passthrough","stats","status","tap"]
+  packages = [
+    ".",
+    "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
+    "codes",
+    "connectivity",
+    "credentials",
+    "encoding",
+    "encoding/proto",
+    "grpclog",
+    "internal",
+    "internal/backoff",
+    "internal/channelz",
+    "internal/envconfig",
+    "internal/grpcrand",
+    "internal/transport",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "reflection",
+    "reflection/grpc_reflection_v1alpha",
+    "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
+    "stats",
+    "status",
+    "tap"
+  ]
   revision = "8dea3dc473e90c8179e519d91302d0597c0ca1d1"
   version = "v1.15.0"
 
@@ -436,42 +435,143 @@
 [[projects]]
   branch = "release-1.9"
   name = "k8s.io/api"
-  packages = ["admission/v1beta1","admissionregistration/v1alpha1","admissionregistration/v1beta1","apps/v1","apps/v1beta1","apps/v1beta2","authentication/v1","authentication/v1beta1","authorization/v1","authorization/v1beta1","autoscaling/v1","autoscaling/v2beta1","batch/v1","batch/v1beta1","batch/v2alpha1","certificates/v1beta1","core/v1","events/v1beta1","extensions/v1beta1","networking/v1","policy/v1beta1","rbac/v1","rbac/v1alpha1","rbac/v1beta1","scheduling/v1alpha1","settings/v1alpha1","storage/v1","storage/v1alpha1","storage/v1beta1"]
+  packages = [
+    "admissionregistration/v1alpha1",
+    "admissionregistration/v1beta1",
+    "apps/v1",
+    "apps/v1beta1",
+    "apps/v1beta2",
+    "authentication/v1",
+    "authentication/v1beta1",
+    "authorization/v1",
+    "authorization/v1beta1",
+    "autoscaling/v1",
+    "autoscaling/v2beta1",
+    "batch/v1",
+    "batch/v1beta1",
+    "batch/v2alpha1",
+    "certificates/v1beta1",
+    "core/v1",
+    "events/v1beta1",
+    "extensions/v1beta1",
+    "networking/v1",
+    "policy/v1beta1",
+    "rbac/v1",
+    "rbac/v1alpha1",
+    "rbac/v1beta1",
+    "scheduling/v1alpha1",
+    "settings/v1alpha1",
+    "storage/v1",
+    "storage/v1alpha1",
+    "storage/v1beta1"
+  ]
   revision = "9273ee02527c608cecc74969b3e489f5dba686da"
 
 [[projects]]
   branch = "release-1.9"
   name = "k8s.io/apimachinery"
-  packages = ["pkg/api/equality","pkg/api/errors","pkg/api/meta","pkg/api/resource","pkg/api/validation","pkg/api/validation/path","pkg/apimachinery","pkg/apimachinery/announced","pkg/apimachinery/registered","pkg/apis/meta/internalversion","pkg/apis/meta/v1","pkg/apis/meta/v1/unstructured","pkg/apis/meta/v1/validation","pkg/apis/meta/v1alpha1","pkg/conversion","pkg/conversion/queryparams","pkg/fields","pkg/labels","pkg/runtime","pkg/runtime/schema","pkg/runtime/serializer","pkg/runtime/serializer/json","pkg/runtime/serializer/protobuf","pkg/runtime/serializer/recognizer","pkg/runtime/serializer/streaming","pkg/runtime/serializer/versioning","pkg/selection","pkg/types","pkg/util/cache","pkg/util/clock","pkg/util/diff","pkg/util/errors","pkg/util/framer","pkg/util/httpstream","pkg/util/intstr","pkg/util/json","pkg/util/mergepatch","pkg/util/net","pkg/util/proxy","pkg/util/rand","pkg/util/runtime","pkg/util/sets","pkg/util/strategicpatch","pkg/util/uuid","pkg/util/validation","pkg/util/validation/field","pkg/util/wait","pkg/util/waitgroup","pkg/util/yaml","pkg/version","pkg/watch","third_party/forked/golang/json","third_party/forked/golang/netutil","third_party/forked/golang/reflect"]
+  packages = [
+    "pkg/api/errors",
+    "pkg/api/meta",
+    "pkg/api/resource",
+    "pkg/apis/meta/v1",
+    "pkg/apis/meta/v1/unstructured",
+    "pkg/apis/meta/v1alpha1",
+    "pkg/conversion",
+    "pkg/conversion/queryparams",
+    "pkg/fields",
+    "pkg/labels",
+    "pkg/runtime",
+    "pkg/runtime/schema",
+    "pkg/runtime/serializer",
+    "pkg/runtime/serializer/json",
+    "pkg/runtime/serializer/protobuf",
+    "pkg/runtime/serializer/recognizer",
+    "pkg/runtime/serializer/streaming",
+    "pkg/runtime/serializer/versioning",
+    "pkg/selection",
+    "pkg/types",
+    "pkg/util/clock",
+    "pkg/util/errors",
+    "pkg/util/framer",
+    "pkg/util/intstr",
+    "pkg/util/json",
+    "pkg/util/net",
+    "pkg/util/runtime",
+    "pkg/util/sets",
+    "pkg/util/validation",
+    "pkg/util/validation/field",
+    "pkg/util/wait",
+    "pkg/util/yaml",
+    "pkg/version",
+    "pkg/watch",
+    "third_party/forked/golang/reflect"
+  ]
   revision = "fb40df2b502912cbe3a93aa61c2b2487f39cb42f"
-
-[[projects]]
-  branch = "release-1.9"
-  name = "k8s.io/apiserver"
-  packages = ["pkg/admission","pkg/admission/configuration","pkg/admission/initializer","pkg/admission/metrics","pkg/admission/plugin/initialization","pkg/admission/plugin/namespace/lifecycle","pkg/admission/plugin/webhook/config","pkg/admission/plugin/webhook/config/apis/webhookadmission","pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1","pkg/admission/plugin/webhook/errors","pkg/admission/plugin/webhook/mutating","pkg/admission/plugin/webhook/namespace","pkg/admission/plugin/webhook/request","pkg/admission/plugin/webhook/rules","pkg/admission/plugin/webhook/validating","pkg/admission/plugin/webhook/versioned","pkg/apis/apiserver","pkg/apis/apiserver/install","pkg/apis/apiserver/v1alpha1","pkg/apis/audit","pkg/apis/audit/v1alpha1","pkg/apis/audit/v1beta1","pkg/apis/audit/validation","pkg/audit","pkg/audit/policy","pkg/authentication/authenticator","pkg/authentication/authenticatorfactory","pkg/authentication/group","pkg/authentication/request/anonymous","pkg/authentication/request/bearertoken","pkg/authentication/request/headerrequest","pkg/authentication/request/union","pkg/authentication/request/websocket","pkg/authentication/request/x509","pkg/authentication/serviceaccount","pkg/authentication/token/tokenfile","pkg/authentication/user","pkg/authorization/authorizer","pkg/authorization/authorizerfactory","pkg/authorization/union","pkg/endpoints","pkg/endpoints/discovery","pkg/endpoints/filters","pkg/endpoints/handlers","pkg/endpoints/handlers/negotiation","pkg/endpoints/handlers/responsewriters","pkg/endpoints/metrics","pkg/endpoints/openapi","pkg/endpoints/request","pkg/features","pkg/registry/generic","pkg/registry/generic/registry","pkg/registry/rest","pkg/server","pkg/server/filters","pkg/server/healthz","pkg/server/httplog","pkg/server/mux","pkg/server/routes","pkg/server/routes/data/swagger","pkg/storage","pkg/storage/errors","pkg/storage/etcd","pkg/storage/etcd/metrics","pkg/storage/etcd/util","pkg/storage/etcd3","pkg/storage/names","pkg/storage/storagebackend","pkg/storage/storagebackend/factory","pkg/storage/value","pkg/util/feature","pkg/util/flushwriter","pkg/util/trace","pkg/util/webhook","pkg/util/wsstream","plugin/pkg/authenticator/token/webhook","plugin/pkg/authorizer/webhook"]
-  revision = "b2fdecc78668ca10ae83e151a11d8c4cbfce9431"
 
 [[projects]]
   branch = "release-6.0"
   name = "k8s.io/client-go"
-  packages = ["discovery","informers","informers/admissionregistration","informers/admissionregistration/v1alpha1","informers/admissionregistration/v1beta1","informers/apps","informers/apps/v1","informers/apps/v1beta1","informers/apps/v1beta2","informers/autoscaling","informers/autoscaling/v1","informers/autoscaling/v2beta1","informers/batch","informers/batch/v1","informers/batch/v1beta1","informers/batch/v2alpha1","informers/certificates","informers/certificates/v1beta1","informers/core","informers/core/v1","informers/events","informers/events/v1beta1","informers/extensions","informers/extensions/v1beta1","informers/internalinterfaces","informers/networking","informers/networking/v1","informers/policy","informers/policy/v1beta1","informers/rbac","informers/rbac/v1","informers/rbac/v1alpha1","informers/rbac/v1beta1","informers/scheduling","informers/scheduling/v1alpha1","informers/settings","informers/settings/v1alpha1","informers/storage","informers/storage/v1","informers/storage/v1alpha1","informers/storage/v1beta1","kubernetes","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/admissionregistration/v1beta1","kubernetes/typed/apps/v1","kubernetes/typed/apps/v1beta1","kubernetes/typed/apps/v1beta2","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1beta1","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v2beta1","kubernetes/typed/batch/v1","kubernetes/typed/batch/v1beta1","kubernetes/typed/batch/v2alpha1","kubernetes/typed/certificates/v1beta1","kubernetes/typed/core/v1","kubernetes/typed/events/v1beta1","kubernetes/typed/extensions/v1beta1","kubernetes/typed/networking/v1","kubernetes/typed/policy/v1beta1","kubernetes/typed/rbac/v1","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1beta1","kubernetes/typed/scheduling/v1alpha1","kubernetes/typed/settings/v1alpha1","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1alpha1","kubernetes/typed/storage/v1beta1","listers/admissionregistration/v1alpha1","listers/admissionregistration/v1beta1","listers/apps/v1","listers/apps/v1beta1","listers/apps/v1beta2","listers/autoscaling/v1","listers/autoscaling/v2beta1","listers/batch/v1","listers/batch/v1beta1","listers/batch/v2alpha1","listers/certificates/v1beta1","listers/core/v1","listers/events/v1beta1","listers/extensions/v1beta1","listers/networking/v1","listers/policy/v1beta1","listers/rbac/v1","listers/rbac/v1alpha1","listers/rbac/v1beta1","listers/scheduling/v1alpha1","listers/settings/v1alpha1","listers/storage/v1","listers/storage/v1alpha1","listers/storage/v1beta1","pkg/version","plugin/pkg/client/auth/oidc","rest","rest/watch","tools/auth","tools/cache","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","tools/pager","tools/reference","transport","util/buffer","util/cert","util/flowcontrol","util/homedir","util/integer"]
+  packages = [
+    "discovery",
+    "kubernetes",
+    "kubernetes/scheme",
+    "kubernetes/typed/admissionregistration/v1alpha1",
+    "kubernetes/typed/admissionregistration/v1beta1",
+    "kubernetes/typed/apps/v1",
+    "kubernetes/typed/apps/v1beta1",
+    "kubernetes/typed/apps/v1beta2",
+    "kubernetes/typed/authentication/v1",
+    "kubernetes/typed/authentication/v1beta1",
+    "kubernetes/typed/authorization/v1",
+    "kubernetes/typed/authorization/v1beta1",
+    "kubernetes/typed/autoscaling/v1",
+    "kubernetes/typed/autoscaling/v2beta1",
+    "kubernetes/typed/batch/v1",
+    "kubernetes/typed/batch/v1beta1",
+    "kubernetes/typed/batch/v2alpha1",
+    "kubernetes/typed/certificates/v1beta1",
+    "kubernetes/typed/core/v1",
+    "kubernetes/typed/events/v1beta1",
+    "kubernetes/typed/extensions/v1beta1",
+    "kubernetes/typed/networking/v1",
+    "kubernetes/typed/policy/v1beta1",
+    "kubernetes/typed/rbac/v1",
+    "kubernetes/typed/rbac/v1alpha1",
+    "kubernetes/typed/rbac/v1beta1",
+    "kubernetes/typed/scheduling/v1alpha1",
+    "kubernetes/typed/settings/v1alpha1",
+    "kubernetes/typed/storage/v1",
+    "kubernetes/typed/storage/v1alpha1",
+    "kubernetes/typed/storage/v1beta1",
+    "pkg/version",
+    "plugin/pkg/client/auth/oidc",
+    "rest",
+    "rest/watch",
+    "tools/auth",
+    "tools/clientcmd",
+    "tools/clientcmd/api",
+    "tools/clientcmd/api/latest",
+    "tools/clientcmd/api/v1",
+    "tools/metrics",
+    "tools/reference",
+    "transport",
+    "util/cert",
+    "util/flowcontrol",
+    "util/homedir",
+    "util/integer"
+  ]
   revision = "115d23201cc1aa2260c19f8f6bb79d400d123dbd"
 
 [[projects]]
   branch = "master"
   name = "k8s.io/kube-openapi"
-  packages = ["pkg/builder","pkg/common","pkg/handler","pkg/util","pkg/util/proto"]
+  packages = ["pkg/common"]
   revision = "e3762e86a74c878ffed47484592986685639c2cd"
-
-[[projects]]
-  branch = "master"
-  name = "sigs.k8s.io/cluster-api"
-  packages = ["pkg/apis/cluster","pkg/apis/cluster/common","pkg/apis/cluster/v1alpha1"]
-  revision = "ba672fe598bc56a7fd155cf959ca6ce6d1882cb8"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6320a4a3efa00702995cff8405af168e2e2eba0e6b463cf15e37d6f773d43d9a"
+  inputs-digest = "235d0b42c181c1896762d58b9993f21e065bf83237768f0dca177883ffbded12"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/internal/apiserver/cluster.go
+++ b/internal/apiserver/cluster.go
@@ -2,6 +2,7 @@ package apiserver
 
 import (
 	"fmt"
+
 	"golang.org/x/net/context"
 
 	pb "github.com/samsung-cnct/cma-vmware/pkg/generated/api"

--- a/internal/apiserver/clusterapi.go
+++ b/internal/apiserver/clusterapi.go
@@ -106,7 +106,7 @@ func PrepareNodes(cluster SSHClusterParams) error {
 	cluster.PublicKey := public
 
 	for _, node := range cluster.ControlPlaneNodes {
-		setupPrivateKeyAccess(node, print, public)
+		setupPrivateKeyAccess(node, private, public)
 	}
 
 	for _, node := range cluster.WorkerNodes {

--- a/pkg/util/ssh.go
+++ b/pkg/util/ssh.go
@@ -1,0 +1,56 @@
+package util
+
+import (
+	"fmt"
+	// "net"
+	// "os"
+
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// GenerateSSHKeyPair creates a ECDSA a x509 ASN.1-DER format-PEM encoded private
+// key string and a SHA256 encoded public key string
+func GenerateSSHKeyPair() (private string, public string, err error) {
+	curve := elliptic.P256()
+	privateKey, err := ecdsa.GenerateKey(curve, rand.Reader)
+	if err != nil {
+		fmt.Println("Error generating private key")
+		return "", "", err
+	}
+
+	// validate private key
+	publicKey := &privateKey.PublicKey
+	if !curve.IsOnCurve(publicKey.X, publicKey.Y) {
+		fmt.Println("Error validating private key")
+		return "", "", err
+	}
+
+	// convert to x509 ASN.1, DER format
+	privateDERBytes, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		fmt.Println("Error encoding private key")
+		return "", "", err
+	}
+
+	// generate pem encoded private key
+	privatePEMBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: privateDERBytes,
+	})
+
+	// generate public key fingerprint (problem)
+	sshPubKey, err := ssh.NewPublicKey(publicKey)
+	if err != nil {
+		fmt.Println("Error creating ssh public key")
+		return "", "", err
+	}
+	pubKeyBytes := ssh.MarshalAuthorizedKey(sshPubKey)
+
+	return string(privatePEMBytes), string(pubKeyBytes), nil
+}

--- a/pkg/util/ssh_test.go
+++ b/pkg/util/ssh_test.go
@@ -27,7 +27,6 @@ func TestGenerateSSHKeyPair(t *testing.T) {
 		t.Errorf("Invalid private key generated")
 		return
 	}
-	//t.Logf("private key validated:\n%s\n", private)
 
 	// validate public key
 	sshPubKey, err := ssh.NewPublicKey(ecdsaPublicKey)
@@ -40,7 +39,6 @@ func TestGenerateSSHKeyPair(t *testing.T) {
 		t.Errorf("Invalid public key generated")
 		return
 	}
-	//t.Logf("public key validated:\n%s\n", public)
 }
 
 // This test requires:
@@ -69,7 +67,6 @@ func TestAddPublicKeyToRemoteNode(t *testing.T) {
 			t.Fatal(err)
 		}
 		parsedKey := string(ssh.MarshalAuthorizedKey(sshPublicKey))
-		//t.Logf("parsed key: %s\n", parsedKey)
 
 		if public == parsedKey {
 			foundKey = true

--- a/pkg/util/ssh_test.go
+++ b/pkg/util/ssh_test.go
@@ -47,19 +47,13 @@ func TestGenerateSSHKeyPair(t *testing.T) {
 //   - SSHD be running locally (mac: sudo systemsetup -setremotelogin on)
 //   - SSH_TEST_PASSWORD environment set and exported
 func TestAddPublicKeyToRemoteNode(t *testing.T) {
-	_, public, err := GenerateSSHKeyPair()
-	if err != nil {
-		t.Errorf("Error generating ssh key pair: %s", err)
-		return
-	}
-
 	username := os.Getenv("USER")
 	password := os.Getenv("SSH_TEST_PASSWORD")
 	if password == "" {
 		t.Skipf("Skipping because SSH_TEST_PASSWORD is not set and/or exported")
 		return
 	}
-	AddPublicKeyToRemoteNode("localhost", "22", username, password, public)
+	_, public, err := generateKeyPairAndAddToRemote(t, "localhost", "22", username, password)
 
 	authKeysFile := filepath.Join(os.Getenv("HOME"), ".ssh", "authorized_keys")
 	authorizedKeysBytes, err := ioutil.ReadFile(authKeysFile)
@@ -86,4 +80,48 @@ func TestAddPublicKeyToRemoteNode(t *testing.T) {
 	if !foundKey {
 		t.Errorf("Did not find the key: %s", public)
 	}
+}
+
+// This test requires:
+//   - SSHD be running locally (mac: sudo systemsetup -setremotelogin on)
+//   - SSH_TEST_PASSWORD environment set and exported
+func TestPublicKeyAccess(t *testing.T) {
+	username := os.Getenv("USER")
+	password := os.Getenv("SSH_TEST_PASSWORD")
+	if password == "" {
+		t.Skipf("Skipping because SSH_TEST_PASSWORD is not set and/or exported")
+		return
+	}
+	private, _, err := generateKeyPairAndAddToRemote(t, "localhost", "22", username, password)
+
+	// Test private key
+	testCmd := "echo cma-vmware: $(date) >> ~/.ssh/test-pvka"
+
+	authMethod, err := SSHAuthMethPublicKey(private)
+	if err != nil {
+		t.Errorf("Failed to generate public key access for ssh")
+		return
+	}
+
+	err = ExecuteCommandOnRemoteNode("localhost", "22", username, authMethod, testCmd)
+	if err != nil {
+		t.Errorf("Failed to execute test command via private key")
+		return
+	}
+}
+
+func generateKeyPairAndAddToRemote(t *testing.T, host string, port string, username string, password string) (private string, public string, err error) {
+	private, public, err = GenerateSSHKeyPair()
+	if err != nil {
+		t.Errorf("Error generating ssh key pair: %s", err)
+		return "", "", err
+	}
+
+	err = AddPublicKeyToRemoteNode(host, port, username, password, public)
+	if err != nil {
+		t.Errorf("Error adding public key to remote node")
+		return "", "", err
+	}
+
+	return private, public, nil
 }

--- a/pkg/util/ssh_test.go
+++ b/pkg/util/ssh_test.go
@@ -3,6 +3,9 @@ package util
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"golang.org/x/crypto/ssh"
@@ -24,7 +27,7 @@ func TestGenerateSSHKeyPair(t *testing.T) {
 		t.Errorf("Invalid private key generated")
 		return
 	}
-	//t.Logf("private key validated: %s", private)
+	//t.Logf("private key validated:\n%s\n", private)
 
 	// validate public key
 	sshPubKey, err := ssh.NewPublicKey(ecdsaPublicKey)
@@ -37,5 +40,50 @@ func TestGenerateSSHKeyPair(t *testing.T) {
 		t.Errorf("Invalid public key generated")
 		return
 	}
-	//t.Logf("public key validated: %s", public)
+	//t.Logf("public key validated:\n%s\n", public)
+}
+
+// This test requires:
+//   - SSHD be running locally (mac: sudo systemsetup -setremotelogin on)
+//   - SSH_TEST_PASSWORD environment set and exported
+func TestAddPublicKeyToRemoteNode(t *testing.T) {
+	_, public, err := GenerateSSHKeyPair()
+	if err != nil {
+		t.Errorf("Error generating ssh key pair: %s", err)
+		return
+	}
+
+	username := os.Getenv("USER")
+	password := os.Getenv("SSH_TEST_PASSWORD")
+	if password == "" {
+		t.Skipf("Skipping because SSH_TEST_PASSWORD is not set and/or exported")
+		return
+	}
+	AddPublicKeyToRemoteNode("localhost", "22", username, password, public)
+
+	authKeysFile := filepath.Join(os.Getenv("HOME"), ".ssh", "authorized_keys")
+	authorizedKeysBytes, err := ioutil.ReadFile(authKeysFile)
+	if err != nil {
+		t.Errorf("Failed to load authorized_keys (%s): %v", authKeysFile, err)
+		return
+	}
+
+	foundKey := false
+	for len(authorizedKeysBytes) > 0 {
+		sshPublicKey, _, _, rest, err := ssh.ParseAuthorizedKey(authorizedKeysBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		parsedKey := string(ssh.MarshalAuthorizedKey(sshPublicKey))
+		//t.Logf("parsed key: %s\n", parsedKey)
+
+		if public == parsedKey {
+			foundKey = true
+		}
+		authorizedKeysBytes = rest
+	}
+
+	if !foundKey {
+		t.Errorf("Did not find the key: %s", public)
+	}
 }

--- a/pkg/util/ssh_test.go
+++ b/pkg/util/ssh_test.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func TestGenerateSSHKeyPair(t *testing.T) {
+	private, public, err := GenerateSSHKeyPair()
+	if err != nil {
+		t.Errorf("Error generating ssh key pair: %s", err)
+		return
+	}
+
+	// validate private key
+	pemBlock, _ := pem.Decode([]byte(private))
+	ecdsaPrivateKey, err := x509.ParseECPrivateKey(pemBlock.Bytes)
+	ecdsaPublicKey := &ecdsaPrivateKey.PublicKey
+
+	if !ecdsaPublicKey.Curve.IsOnCurve(ecdsaPublicKey.X, ecdsaPublicKey.Y) {
+		t.Errorf("Invalid private key generated")
+		return
+	}
+	//t.Logf("private key validated: %s", private)
+
+	// validate public key
+	sshPubKey, err := ssh.NewPublicKey(ecdsaPublicKey)
+	if err != nil {
+		t.Errorf("Invalid ssh public key generation: %s", err)
+		return
+	}
+	testPublicKey := ssh.MarshalAuthorizedKey(sshPubKey)
+	if public != string(testPublicKey) {
+		t.Errorf("Invalid public key generated")
+		return
+	}
+	//t.Logf("public key validated: %s", public)
+}


### PR DESCRIPTION
This PR dynamically generates a private/public keypair on cluster creation, then uses the provided username/password for control and worker nodes to login into each node via ssh, and setup public key access for ssh. The private key is then properly set in the cluster manifests (secret/cluster-private-key).