### PR TITLE
fixing int32 to string conversion issue on ssh dialing

### DIFF
--- a/internal/apiserver/clusterapi.go
+++ b/internal/apiserver/clusterapi.go
@@ -131,12 +131,12 @@ func setupPrivateKeyAccess(machine SSHMachineParams, privateKey string, publicKe
 
 	err := util.AddPublicKeyToRemoteNode(
 		machine.Host,
-		string(machine.Port),
+		machine.Port,
 		machine.Username,
 		machine.Password,
 		publicKey)
 	if err != nil {
-		fmt.Printf("Failed to add public key to %s@%s:%s\n",
+		fmt.Printf("ERROR: Failed to add public key to %s@%s:%d\n",
 			machine.Username, machine.Host, machine.Port)
 		return err
 	}
@@ -146,13 +146,13 @@ func setupPrivateKeyAccess(machine SSHMachineParams, privateKey string, publicKe
 
 	authMethod, err := util.SSHAuthMethPublicKey(privateKey)
 	if err != nil {
-		fmt.Printf("Failed generate a public key for ssh authentication")
+		fmt.Printf("ERROR: Failed generate a public key for ssh authentication")
 		return err
 	}
 
-	err = util.ExecuteCommandOnRemoteNode(machine.Host, string(machine.Port), machine.Username, authMethod, testCmd)
+	err = util.ExecuteCommandOnRemoteNode(machine.Host, machine.Port, machine.Username, authMethod, testCmd)
 	if err != nil {
-		fmt.Printf("Failed to execute test command via private key on remote node")
+		fmt.Printf("ERROR: Failed to execute test command via private key on remote node")
 		return err
 	}
 

--- a/pkg/util/ssh.go
+++ b/pkg/util/ssh.go
@@ -57,7 +57,7 @@ func GenerateSSHKeyPair() (private string, public string, err error) {
 }
 
 // AddPublicKeyToRemoteNode will add the publicKey to the username@host:port's authorized_keys file w/password
-func AddPublicKeyToRemoteNode(host string, port string, username string, password string, publicKey string) error {
+func AddPublicKeyToRemoteNode(host string, port int32, username string, password string, publicKey string) error {
 	var remoteAuthorizedKeysFile = filepath.Join("${HOME}", ".ssh", "authorized_keys")
 
 	remoteCmd := fmt.Sprintf("echo %s >> %s && chmod 600 %s",
@@ -75,10 +75,10 @@ func AddPublicKeyToRemoteNode(host string, port string, username string, passwor
 }
 
 // ExecuteCommandOnRemoteNode executes the commmand on username@host:port using the authMethed
-func ExecuteCommandOnRemoteNode(host string, port string, username string, authMethod ssh.AuthMethod, command string) error {
+func ExecuteCommandOnRemoteNode(host string, port int32, username string, authMethod ssh.AuthMethod, command string) error {
 	config := sshClientConfig(username, authMethod)
 
-	client, err := ssh.Dial("tcp", fmt.Sprintf("%s:%s", host, port), config)
+	client, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", host, port), config)
 	if err != nil {
 		fmt.Printf("ERROR: Failed to ssh into remote node (%s): %s\n", host, err)
 		return err

--- a/pkg/util/ssh_test.go
+++ b/pkg/util/ssh_test.go
@@ -51,7 +51,7 @@ func TestAddPublicKeyToRemoteNode(t *testing.T) {
 		t.Skipf("Skipping because SSH_TEST_PASSWORD is not set and/or exported")
 		return
 	}
-	_, public, err := generateKeyPairAndAddToRemote(t, "localhost", "22", username, password)
+	_, public, err := generateKeyPairAndAddToRemote(t, "localhost", 22, username, password)
 
 	authKeysFile := filepath.Join(os.Getenv("HOME"), ".ssh", "authorized_keys")
 	authorizedKeysBytes, err := ioutil.ReadFile(authKeysFile)
@@ -89,7 +89,7 @@ func TestPublicKeyAccess(t *testing.T) {
 		t.Skipf("Skipping because SSH_TEST_PASSWORD is not set and/or exported")
 		return
 	}
-	private, _, err := generateKeyPairAndAddToRemote(t, "localhost", "22", username, password)
+	private, _, err := generateKeyPairAndAddToRemote(t, "localhost", 22, username, password)
 
 	// Test private key
 	testCmd := "echo cma-vmware: $(date) >> ~/.ssh/test-pvka"
@@ -100,14 +100,14 @@ func TestPublicKeyAccess(t *testing.T) {
 		return
 	}
 
-	err = ExecuteCommandOnRemoteNode("localhost", "22", username, authMethod, testCmd)
+	err = ExecuteCommandOnRemoteNode("localhost", 22, username, authMethod, testCmd)
 	if err != nil {
 		t.Errorf("Failed to execute test command via private key")
 		return
 	}
 }
 
-func generateKeyPairAndAddToRemote(t *testing.T, host string, port string, username string, password string) (private string, public string, err error) {
+func generateKeyPairAndAddToRemote(t *testing.T, host string, port int32, username string, password string) (private string, public string, err error) {
 	private, public, err = GenerateSSHKeyPair()
 	if err != nil {
 		t.Errorf("Error generating ssh key pair: %s", err)


### PR DESCRIPTION
The SSHMachineParams.Port (int32) was not being converted correctly to a string (internal/apiserver/clusterapi.go:134) and when executed on the ssh dial (pkg/util/ssh.go:81) would fail.