### PR TITLE
Fix privatekey encoding

### DIFF
--- a/internal/apiserver/clusterapi.go
+++ b/internal/apiserver/clusterapi.go
@@ -24,8 +24,7 @@ const (
 
 type SSHClusterParams struct {
 	Name              string
-	PrivateKey        string
-	Base64PrivateKey  string
+	PrivateKey        string // This is a base64 encoded, PEM EC private key
 	PublicKey         string
 	K8SVersion        string
 	ControlPlaneNodes []SSHMachineParams
@@ -107,8 +106,7 @@ func PrepareNodes(cluster *SSHClusterParams) error {
 		return err
 	}
 
-	cluster.PrivateKey = private
-	cluster.Base64PrivateKey = base64.StdEncoding.EncodeToString([]byte(cluster.PrivateKey))
+	cluster.PrivateKey = base64.StdEncoding.EncodeToString([]byte(cluster.PrivateKey))
 	cluster.PublicKey = public
 
 	for _, node := range cluster.ControlPlaneNodes {

--- a/internal/apiserver/clusterapi.go
+++ b/internal/apiserver/clusterapi.go
@@ -25,6 +25,7 @@ const (
 type SSHClusterParams struct {
 	Name              string
 	PrivateKey        string
+	Base64PrivateKey  string
 	PublicKey         string
 	K8SVersion        string
 	ControlPlaneNodes []SSHMachineParams
@@ -91,9 +92,6 @@ func RenderClusterManifests(cluster SSHClusterParams) (string, error) {
 		return "", err
 	}
 
-	encodedPrivateKey := base64.StdEncoding.EncodeToString([]byte(cluster.PrivateKey))
-	cluster.PrivateKey = encodedPrivateKey
-
 	var tmplBuf bytes.Buffer
 	err = tmpl.Execute(&tmplBuf, cluster)
 	if err != nil {
@@ -110,6 +108,7 @@ func PrepareNodes(cluster *SSHClusterParams) error {
 	}
 
 	cluster.PrivateKey = private
+	cluster.Base64PrivateKey = base64.StdEncoding.EncodeToString([]byte(cluster.PrivateKey))
 	cluster.PublicKey = public
 
 	for _, node := range cluster.ControlPlaneNodes {

--- a/internal/apiserver/clusterapi.go
+++ b/internal/apiserver/clusterapi.go
@@ -91,6 +91,9 @@ func RenderClusterManifests(cluster SSHClusterParams) (string, error) {
 		return "", err
 	}
 
+	encodedPrivateKey := base64.StdEncoding.EncodeToString([]byte(cluster.PrivateKey))
+	cluster.PrivateKey = encodedPrivateKey
+
 	var tmplBuf bytes.Buffer
 	err = tmpl.Execute(&tmplBuf, cluster)
 	if err != nil {

--- a/internal/apiserver/clusterapitemplates.go
+++ b/internal/apiserver/clusterapitemplates.go
@@ -79,7 +79,7 @@ metadata:
   name: cluster-private-key
   namespace: {{ $.Name }}
 data:
-  private-key: {{ $.PrivateKey }}
+  private-key: {{ $.Base64PrivateKey }}
   pass-phrase: ""
 `
 

--- a/internal/apiserver/clusterapitemplates.go
+++ b/internal/apiserver/clusterapitemplates.go
@@ -79,7 +79,7 @@ metadata:
   name: cluster-private-key
   namespace: {{ $.Name }}
 data:
-  private-key: {{ $.Base64PrivateKey }}
+  private-key: {{ $.PrivateKey }}
   pass-phrase: ""
 `
 


### PR DESCRIPTION
When the cluster manifests for the cluster is being run by kubectl, and after template rendering, I get the following error:

`Command kubectl stderr: error: error parsing STDIN: error converting YAML to JSON: yaml: line 9: could not find expected ':'.`

The cluster and machine CRs are all created in the cluster. Only the secret/cluster-private-key does not exist. This should fix that since the private key is stored as a PEM encoded string in the `SSHClusterParams` struct, and not a base64 string as a secret needs to be. This fixes that.