### PR TITLE
Upgrade bug fixes, and using secret kubeconfig

### DIFF
--- a/internal/apiserver/cluster.go
+++ b/internal/apiserver/cluster.go
@@ -126,8 +126,14 @@ func (s *Server) GetUpgradeClusterInformation(ctx context.Context, in *pb.GetUpg
 }
 
 func (s *Server) UpgradeCluster(ctx context.Context, in *pb.UpgradeClusterMsg) (*pb.UpgradeClusterReply, error) {
-	err := UpgradeSSHCluster(in.Name, in.Version)
+	kubeconfigBytes, err := GetKubeConfig(in.Name)
 	if err != nil {
+		fmt.Printf("INFO: UpgradeCluster unable to getKubeconfig secret for cluster %s\n", in.Name)
+		return nil, status.Error(codes.NotFound, err.Error())
+	}
+	err = UpgradeSSHCluster(in.Name, in.Version, kubeconfigBytes)
+	if err != nil {
+		fmt.Printf("ERROR: UpgradeCluster, %v, err %v\n", in.Name, err)
 		return &pb.UpgradeClusterReply{
 			Ok: true,
 		}, err


### PR DESCRIPTION
waitForKubeletVersion re-uses kubeletMatchVersion so that parsing of get nodes is done once. The matching case in waitForKubeletVersion now signals done.  It Ignore errors from kubeletMatchVersion(which calls RunCommand) and logs a WARN, since the master can be unavailable to kubectl for a while during upgrade.

kubeletMatchVersion uses RunCommand as is, found there was no need to pass in an Env.

Tested well, it looks good!