### PR TITLE
Fixing issue w/creating authorized_keys file

### DIFF
--- a/pkg/util/ssh.go
+++ b/pkg/util/ssh.go
@@ -58,12 +58,15 @@ func GenerateSSHKeyPair() (private string, public string, err error) {
 
 // AddPublicKeyToRemoteNode will add the publicKey to the username@host:port's authorized_keys file w/password
 func AddPublicKeyToRemoteNode(host string, port int32, username string, password string, publicKey string) error {
-	var remoteAuthorizedKeysFile = filepath.Join("${HOME}", ".ssh", "authorized_keys")
+	var sshDir = filepath.Join("${HOME}", ".ssh")
+	var authorizedKeysFile = filepath.Join(sshDir, "authorized_keys")
 
-	remoteCmd := fmt.Sprintf("echo %s >> %s && chmod 600 %s",
+	remoteCmd := fmt.Sprintf("mkdir -p %s && chmod 700 %s && echo %s >> %s && chmod 600 %s",
+		sshDir,
+		sshDir,
 		strings.TrimSuffix(publicKey, "\n"),
-		remoteAuthorizedKeysFile,
-		remoteAuthorizedKeysFile)
+		authorizedKeysFile,
+		authorizedKeysFile)
 
 	err := ExecuteCommandOnRemoteNode(host, port, username, ssh.Password(password), remoteCmd)
 	if err != nil {


### PR DESCRIPTION
An issue was discovered during testing (h/t @zachpuck) surrounding the dynamic creation of a public/private key for client nodes. If the remote user account does not have an existing ssh home directory (`${HOME}/.ssh`), the creation of the remote `${HOME}/.ssh/authorized_keys` file will fail.

This fixes that by trying to create the ssh directory before creating the file:

`mkdir -p %s && chmod 700 %s && echo %s >> %s && chmod 600 %s`

If the ssh directory already exists, the `mkdir -p` and `chmod 700` should be effectively harmless.

Also ran ssh unit test manually testing the does-not-exist-ssh directory case and also the does-exist-ssh directory case still works.