### PR TITLE
Add in cluster tests

### DIFF
--- a/tests/create-cluster.sh
+++ b/tests/create-cluster.sh
@@ -55,7 +55,7 @@ DATA=$(
     "network_fabric": "canal"
   },
   "callback": {
-    "url": "https://example.org/unused",
+    "url": "unused",
     "request_id": "1234"
   }
 }
@@ -68,7 +68,7 @@ main() {
     -H 'Cache-Control: no-cache' \
     -H 'Content-Type: application/json' \
     -d "${DATA}" \
-    -sk
+    -iks
 }
 
 main

--- a/tests/create-cluster.sh
+++ b/tests/create-cluster.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+CLUSTER_API=${CLUSTER_API:-cluster-manager-api.cnct.io}
+CLUSTER_API_PORT=${CLUSTER_API_PORT:-443}
+CLUSTER_NAME=${CLUSTER_NAME:-vmware-test-$(date +%s)}
+MASTER_IP=${MASTER_IP:-182.195.81.132}
+WORKER_1_IP=${WORKER_IP:-182.195.81.137}
+K8S_VERSION=${K8S_VERSION:-1.10.6}
+NODE_USER=${NODE_USER:-root}
+
+[[ -n $DEBUG ]] && set -o xtrace
+set -o errexit
+set -o nounset
+set -o pipefail
+
+DATA=$(
+  cat <<JSON
+{
+  "name": "${CLUSTER_NAME}",
+  "provider": {
+    "name": "vmware",
+    "k8s_version": "${K8S_VERSION}",
+    "vmware": {
+      "control_plane_nodes": [
+        {
+          "username": "${NODE_USER}",
+          "host": "${MASTER_IP}",
+          "port": 22,
+          "password": "${NODE_PASSWORD}",
+          "labels": [
+            {
+              "name": "master",
+              "value": "1"
+            }
+          ]
+        }
+      ],
+      "worker_nodes": [
+        {
+          "username": "${NODE_USER}",
+          "host": "${WORKER_1_IP}",
+          "port": 22,
+          "password": "${NODE_PASSWORD}",
+          "labels": [
+            {
+              "name": "worker",
+              "value": "1"
+            }
+          ]
+        }
+      ],
+      "api_endpoint": "172.10.10.1:443"
+    },
+    "high_availability": false,
+    "network_fabric": "canal"
+  },
+  "callback": {
+    "url": "https://example.org/unused",
+    "request_id": "1234"
+  }
+}
+JSON
+)
+
+main() {
+  curl -X POST \
+    "https://${CLUSTER_API}:${CLUSTER_API_PORT}/api/v1/cluster" \
+    -H 'Cache-Control: no-cache' \
+    -H 'Content-Type: application/json' \
+    -d "${DATA}" \
+    -sk
+}
+
+main

--- a/tests/delete-cluster.sh
+++ b/tests/delete-cluster.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+CLUSTER_API=${CLUSTER_API:-cluster-manager-api.cnct.io}
+CLUSTER_API_PORT=${CLUSTER_API_PORT:-443}
+CLUSTER_NAME=${CLUSTER_NAME:-vmware-test-$(date +%s)}
+
+[[ -n $DEBUG ]] && set -o xtrace
+set -o errexit
+set -o nounset
+set -o pipefail
+
+main() {
+  curl -X DELETE \
+    "https://${CLUSTER_API}:${CLUSTER_API_PORT}/api/v1/cluster?name=${CLUSTER_NAME}&provider=vmware&callback.url=http%3A%2F%2Fsomewhere&callback.request_id=35sdf3345sd" \
+    -H 'Cache-Control: no-cache' \
+    -H 'Content-Type: application/json' \
+    -sk
+}
+
+main

--- a/tests/delete-cluster.sh
+++ b/tests/delete-cluster.sh
@@ -11,10 +11,10 @@ set -o pipefail
 
 main() {
   curl -X DELETE \
-    "https://${CLUSTER_API}:${CLUSTER_API_PORT}/api/v1/cluster?name=${CLUSTER_NAME}&provider=vmware&callback.url=http%3A%2F%2Fsomewhere&callback.request_id=35sdf3345sd" \
+    "https://${CLUSTER_API}:${CLUSTER_API_PORT}/api/v1/cluster?name=${CLUSTER_NAME}&provider=vmware&callback.url=http%3A%2F%2Funused&callback.request_id=1234" \
     -H 'Cache-Control: no-cache' \
     -H 'Content-Type: application/json' \
-    -sk
+    -iks
 }
 
 main

--- a/tests/full-test.sh
+++ b/tests/full-test.sh
@@ -5,15 +5,26 @@ __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export CLUSTER_API=${CLUSTER_API:-cluster-manager-api.cnct.io}
 export CLUSTER_API_PORT=${CLUSTER_API_PORT:-443}
 export CLUSTER_NAME=${CLUSTER_NAME:-vmware-test-$(date +%s)}
+export CLUSTER_API_NAMESPACE=${CLUSTER_API_NAMESPACE:-cma}
 
 [[ -n $DEBUG ]] && set -o xtrace
 set -o errexit
 set -o nounset
 set -o pipefail
 
+get-kubeconfig(){
+  kubectl get secrets --namespace $CLUSTER_API_NAMESPACE $CLUSTER_NAME -o yaml |
+    grep kubernetes.kubeconfig |
+    sed 's/  kubernetes.kubeconfig: //' |
+    base64 --decode >kubeconfig.yaml
+}
+
 main() {
   ${__dir}/create-cluster.sh
   ${__dir}/get-cluster.sh
+
+  get-kubeconfig
+
   ${__dir}/delete-cluster.sh
 }
 

--- a/tests/full-test.sh
+++ b/tests/full-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export CLUSTER_API=${CLUSTER_API:-cluster-manager-api.cnct.io}
+export CLUSTER_API_PORT=${CLUSTER_API_PORT:-443}
+export CLUSTER_NAME=${CLUSTER_NAME:-vmware-test-$(date +%s)}
+
+[[ -n $DEBUG ]] && set -o xtrace
+set -o errexit
+set -o nounset
+set -o pipefail
+
+main() {
+  ${__dir}/create-cluster.sh
+  ${__dir}/get-cluster.sh
+  ${__dir}/delete-cluster.sh
+}
+
+main

--- a/tests/get-cluster.sh
+++ b/tests/get-cluster.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+CLUSTER_API=${CLUSTER_API:-cluster-manager-api.cnct.io}
+CLUSTER_API_PORT=${CLUSTER_API_PORT:-443}
+CLUSTER_NAME=${CLUSTER_NAME:-vmware-test-$(date +%s)}
+
+[[ -n $DEBUG ]] && set -o xtrace
+set -o errexit
+set -o nounset
+set -o pipefail
+
+main() {
+  curl -X GET \
+    "https://${CLUSTER_API}:${CLUSTER_API_PORT}/api/v1/cluster?provider=vmware&name=${CLUSTER_NAME}" \
+    -H 'Cache-Control: no-cache' \
+    -H 'Content-Type: application/json' \
+    -sk
+}
+
+main

--- a/tests/get-cluster.sh
+++ b/tests/get-cluster.sh
@@ -14,7 +14,7 @@ main() {
     "https://${CLUSTER_API}:${CLUSTER_API_PORT}/api/v1/cluster?provider=vmware&name=${CLUSTER_NAME}" \
     -H 'Cache-Control: no-cache' \
     -H 'Content-Type: application/json' \
-    -sk
+    -iks
 }
 
 main


### PR DESCRIPTION
This is a baseline. It uses a subset of the CMA to create, get, and delete a client cluster.
Added to that is the retrieval of the `kubeconfig` for the client cluster.
Follow on pull requests will add an exercise of the client cluster.