### PR TITLE
new label role for deleting machines in order, on create check if exists

### DIFF
--- a/internal/apiserver/cluster.go
+++ b/internal/apiserver/cluster.go
@@ -12,7 +12,11 @@ import (
 )
 
 func (s *Server) CreateCluster(ctx context.Context, in *pb.CreateClusterMsg) (*pb.CreateClusterReply, error) {
-	err := CreateSSHCluster(in)
+	clusterExists, err := ClusterExists(in.Name)
+	if clusterExists {
+		return nil, status.Error(codes.AlreadyExists, "cluster name already exists")
+	}
+	err = CreateSSHCluster(in)
 	if err != nil {
 		// TODO: Make this consistent with how the CMA does logging...
 		fmt.Printf("ERROR: CreateCluster, name %v, err %v\n", in.Name, err)

--- a/internal/apiserver/clusterapi.go
+++ b/internal/apiserver/clusterapi.go
@@ -220,8 +220,8 @@ func DeleteSSHCluster(clusterName string) error {
 	cmdArgs := []string{"--help"}
 	cmdTimeout := time.Duration(maxApplyTimeout) * time.Second
 
-	// Delete workers. Control plane nodes have a non-empty value for the label key controlPlaneVersion.
-	cmdArgs = []string{"delete", "machines", "-n", clusterName, "-l", `!controlPlaneVersion`}
+	// Delete workers.
+	cmdArgs = []string{"delete", "machines", "-n", clusterName, "-l", "role=worker"}
 	_, err := RunCommand(cmdName, cmdArgs, "", cmdTimeout)
 	if err != nil {
 		return err
@@ -234,7 +234,7 @@ func DeleteSSHCluster(clusterName string) error {
 	}
 
 	// Delete control plane.
-	cmdArgs = []string{"delete", "machines", "-n", clusterName, "-l", "controlPlaneVersion"}
+	cmdArgs = []string{"delete", "machines", "-n", clusterName, "-l", "role=controlPlane"}
 	_, err = RunCommand(cmdName, cmdArgs, "", cmdTimeout)
 	if err != nil {
 		return err
@@ -475,8 +475,8 @@ func kubeletVersionMatch(clusterName string, machineName string, expectedVersion
 // specified.  masters should be false when deleting workers.  masters should
 // be true when deleting masters.
 func machinesDeleted(clusterName string, masters bool) (bool, error) {
-	getMastersCmd := []string{"get", "machines", "-n", clusterName, "-l", "controlPlaneVersion"}
-	getWorkersCmd := []string{"get", "machines", "-n", clusterName, "-l", `!controlPlaneVersion`}
+	getMastersCmd := []string{"get", "machines", "-n", clusterName, "-l", "role=controlPlane"}
+	getWorkersCmd := []string{"get", "machines", "-n", clusterName, "-l", "role=worker"}
 	cmdName := kubectlCmd
 	cmdTimeout := time.Duration(maxApplyTimeout) * time.Second
 	var machinesFound bytes.Buffer

--- a/internal/apiserver/clusterapitemplates.go
+++ b/internal/apiserver/clusterapitemplates.go
@@ -32,6 +32,7 @@ metadata:
   namespace: {{ $.Name }}
   labels:
     controlPlaneVersion: {{ $.K8SVersion }}
+    role: controlPlane
 spec:
   providerConfig:
     value:
@@ -56,6 +57,8 @@ kind: Machine
 metadata:
   generateName: worker-
   namespace: {{ $.Name }}
+  labels:
+    role: worker
 spec:
   providerConfig:
     value:
@@ -93,6 +96,7 @@ metadata:
   namespace: {{ $.Name }}
   labels:
     controlPlaneVersion: {{ $.K8SVersion }}
+    role: controlPlane
 spec:
   providerConfig:
     value:
@@ -117,6 +121,8 @@ kind: Machine
 metadata:
   generateName: worker-
   namespace: {{ $.Name }}
+  labels:
+    role: worker
 spec:
   providerConfig:
     value:


### PR DESCRIPTION
Fixes returning AlreadyExists error if attempting to create the same cluster name twice.
Fixes deleting machines in order (workers before controlPlanes) with a more standard method.