### PR TITLE
Made delete and upgrade timeout 10 minutes

### DIFF
--- a/internal/apiserver/clusterapi.go
+++ b/internal/apiserver/clusterapi.go
@@ -22,8 +22,8 @@ const (
 	sshCmd     = "ssh"
 
 	maxApplyTimeout   = 30
-	maxDeleteTimeout  = 120
-	maxUpgradeTimeout = 540 // !? TODO: Determine a better value for this.
+	maxDeleteTimeout  = 600
+	maxUpgradeTimeout = 600 // !? TODO: Determine a better value for this.
 	upgradeRetrySleep = 15
 )
 


### PR DESCRIPTION
Drain can take a while, made both delete and upgrade timeout (per machine) 10 minutes